### PR TITLE
Added getter for url just like a WebSocket has.

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -62,6 +62,7 @@ class Client extends Object with event.Emitter {
   Stream get onMessage => this["message"];
   Stream get onClose => this["close"];
   Stream get onHeartbeat => this["heartbeat"];
+  String get url => this._baseUrl;
 
   send(data) {
     if (readyState == CONNECTING) {


### PR DESCRIPTION
A webSocket exposes the url it has connected to as a getter. It would be nice to have it available in SockJS as well.
