### PR TITLE
Disable connection to external server

### DIFF
--- a/lib/src/transport/websocket.dart
+++ b/lib/src/transport/websocket.dart
@@ -54,18 +54,22 @@ class WebSocketTransport {
 
   static bool get enabled {
     var res = true;
-    var ws;
+    // CHANGE: don't ping echo.websocket.org
 
-    // Ugly detection stuff - must be online
-    try {
-      ws = new WebSocket('ws://echo.websocket.org');
-    } on dynamic catch(e) {
-      res = false;
-    } finally {
-      try {
-        ws.onOpen.listen((e) => ws.close());
-      } catch (_){}
-    }
+    // var ws;
+
+    // // Ugly detection stuff - must be online
+    // try {
+    //   ws = new WebSocket('ws://echo.websocket.org');
+    // } on dynamic catch(e) {
+    //   res = false;
+    // } finally {
+    //   try {
+    //     ws.onOpen.listen((e) => ws.close());
+    //   } catch (_){}
+    // }
+
+    // END CHANGE
 
     return res;
   }


### PR DESCRIPTION
Relying on a real connection to echo.websocket.org for websocket detection is fragile and hard to mock out and should be removed.

@nelsonsilva 
