### PR TITLE
Allow more flexibility in WebSocket probing/detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .project
 packages
+.packages
+pubspec.lock
 

--- a/lib/src/transport/websocket.dart
+++ b/lib/src/transport/websocket.dart
@@ -9,6 +9,8 @@ class WebSocketTransport {
   StreamSubscription closeSubscription;
 
   static create(ri, transUrl, [baseUrl]) => new WebSocketTransport(ri, transUrl);
+  static String probeAddress = 'echo.websocket.org';
+  static bool probeSecure = false;
 
   WebSocketTransport(this.ri, transUrl) {
     var url = '$transUrl/websocket';
@@ -58,7 +60,8 @@ class WebSocketTransport {
 
     // Ugly detection stuff - must be online
     try {
-      ws = new WebSocket('ws://echo.websocket.org');
+      ws = new WebSocket((WebSocketTransport.probeSecure ? 'wss://' : 'ws://') +
+        WebSocketTransport.probeAddress);
     } on dynamic catch(e) {
       res = false;
     } finally {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name:  sockjs_client
-version: 0.2.0
+version: 0.3.0
 description:  A SockJS client in Dart
 homepage: https://github.com/nelsonsilva/sockjs-dart-client
 authors:


### PR DESCRIPTION
If the page using the WebSocket is loaded over https, the probe to ws://echo.websocket.org fails due to browser security.  There are now two static variables in the WebSocketTransport class:

probeAddress (defaults to 'echo.websocket.org')
probeSecure (defaults to false)

Any code using sockjs_client can now fully control the auto-detection process.

Example - to use a secure connection:

```
import "package:sockjs_client/sockjs_client.dart" as SockJS;
...
SockJS.WebSocketTransport.probeSecure = true;
```

Example - to change the detection server:

```
import "package:sockjs_client/sockjs_client.dart" as SockJS;
...
SockJS.WebSocketTransport.probeAddress = 'my.server.com';
```

It's a little kludgy and requires some knowledge of the internal workings of the package, but this required minimal changes to existing code.

References issue #10
